### PR TITLE
Update ipfs related dependencies after git tag rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+- 1.12.x
+
+env:
+  - GO111MODULE=on
+
+script:
+  - make ipcs containerd-binary

--- a/go.mod
+++ b/go.mod
@@ -32,16 +32,10 @@ require (
 	github.com/ipfs/go-ipfs-http-client v0.0.1
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/interface-go-ipfs-core v0.0.1
-	github.com/libp2p/go-flow-metrics v0.2.0 // indirect
-	github.com/libp2p/go-libp2p-crypto v2.0.1+incompatible // indirect
-	github.com/libp2p/go-libp2p-metrics v2.1.7+incompatible // indirect
-	github.com/libp2p/go-libp2p-peer v2.4.0+incompatible // indirect
-	github.com/libp2p/go-libp2p-protocol v1.0.0 // indirect
 	github.com/mistifyio/go-zfs v2.1.1+incompatible // indirect
 	github.com/moby/buildkit v0.3.3
 	github.com/multiformats/go-multiaddr v0.0.2 // indirect
-	github.com/multiformats/go-multiaddr-net v1.6.3 // indirect
-	github.com/multiformats/go-multihash v1.0.8
+	github.com/multiformats/go-multihash v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/opencontainers/runc v0.1.1 // indirect


### PR DESCRIPTION
Fixes #1 

IPFS migrates from gx to go mod for dependencies.
https://github.com/ipfs/go-ipfs/issues/5850

Publishing to gx-go also used to be combined with updating git tags but that is
no longer the case. And after removing gx, they renamed tags to gx/x.x.x to
not mess with go mod's dependency solver.